### PR TITLE
separate rand Reader from metadata generation: 💯

### DIFF
--- a/v1/tv/internal/traceview/context.go
+++ b/v1/tv/internal/traceview/context.go
@@ -50,26 +50,27 @@ func oboeMetadataInit(md *oboeMetadata) int {
 	return 0
 }
 
-func oboeMetadataRandom(md *oboeMetadata) {
+func (md *oboeMetadata) SetRandom() error {
 	if md == nil {
-		return
+		return errors.New("SetRandom on nil oboeMetadata")
 	}
-
 	_, err := rand.Read(md.ids.taskID)
 	if err != nil {
-		return
+		return err
 	}
 	_, err = rand.Read(md.ids.opID)
 	if err != nil {
-		return
+		return err
 	}
+	return nil
 }
 
-func oboeRandomOpID(md *oboeMetadata) {
+func (md *oboeMetadata) SetRandomOpID() error {
 	_, err := rand.Read(md.ids.opID)
 	if err != nil {
-		return
+		return err
 	}
+	return nil
 }
 
 func (ids *oboeIDs) setOpID(opID []byte) {
@@ -251,10 +252,12 @@ func (e *nullEvent) MetadataString() string                                     
 func NewNullContext() SampledContext { return &nullContext{} }
 
 // newContext allocates a context with random metadata (for a new trace).
-func newContext() *context {
+func newContext() SampledContext {
 	ctx := &context{}
 	oboeMetadataInit(&ctx.metadata)
-	oboeMetadataRandom(&ctx.metadata)
+	if err := ctx.metadata.SetRandom(); err != nil {
+		return &nullContext{}
+	}
 	return ctx
 }
 

--- a/v1/tv/internal/traceview/context.go
+++ b/v1/tv/internal/traceview/context.go
@@ -37,40 +37,32 @@ type context struct {
 	metadata oboeMetadata
 }
 
-func oboeMetadataInit(md *oboeMetadata) int {
-	if md == nil {
-		return -1
-	}
-
+func (md *oboeMetadata) Init() {
 	md.taskLen = oboeMaxTaskIDLen
 	md.opLen = oboeMaxOpIDLen
 	md.ids.taskID = make([]byte, oboeMaxTaskIDLen)
-	md.ids.opID = make([]byte, oboeMaxTaskIDLen)
-
-	return 0
+	md.ids.opID = make([]byte, oboeMaxOpIDLen)
 }
+
+// randReader provides random IDs, and can be overridden for testing.
+// set by default to read from the crypto/rand Reader.
+var randReader = rand.Reader
 
 func (md *oboeMetadata) SetRandom() error {
 	if md == nil {
 		return errors.New("SetRandom on nil oboeMetadata")
 	}
-	_, err := rand.Read(md.ids.taskID)
+	_, err := randReader.Read(md.ids.taskID)
 	if err != nil {
 		return err
 	}
-	_, err = rand.Read(md.ids.opID)
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err = randReader.Read(md.ids.opID)
+	return err
 }
 
 func (md *oboeMetadata) SetRandomOpID() error {
-	_, err := rand.Read(md.ids.opID)
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := randReader.Read(md.ids.opID)
+	return err
 }
 
 func (ids *oboeIDs) setOpID(opID []byte) {
@@ -254,7 +246,7 @@ func NewNullContext() SampledContext { return &nullContext{} }
 // newContext allocates a context with random metadata (for a new trace).
 func newContext() SampledContext {
 	ctx := &context{}
-	oboeMetadataInit(&ctx.metadata)
+	ctx.metadata.Init()
 	if err := ctx.metadata.SetRandom(); err != nil {
 		return &nullContext{}
 	}
@@ -263,7 +255,7 @@ func newContext() SampledContext {
 
 func newContextFromMetadataString(mdstr string) *context {
 	ctx := &context{}
-	oboeMetadataInit(&ctx.metadata)
+	ctx.metadata.Init()
 	oboeMetadataFromString(&ctx.metadata, mdstr)
 	return ctx
 }
@@ -299,19 +291,22 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 
 func (ctx *context) Copy() SampledContext {
 	md := oboeMetadata{}
-	oboeMetadataInit(&md)
+	md.Init()
 	copy(md.ids.taskID, ctx.metadata.ids.taskID)
 	copy(md.ids.opID, ctx.metadata.ids.opID)
 	return &context{metadata: md}
 }
 func (ctx *context) IsTracing() bool { return true }
 
-func (ctx *context) NewEvent(label Label, layer string) *event {
+func (ctx *context) NewEvent(label Label, layer string) (*event, error) {
 	return newEvent(&ctx.metadata, label, layer)
 }
 
 func (ctx *context) NewSampledEvent(label Label, layer string, addCtxEdge bool) SampledEvent {
-	e := newEvent(&ctx.metadata, label, layer)
+	e, err := newEvent(&ctx.metadata, label, layer)
+	if err != nil {
+		return &nullEvent{}
+	}
 	if addCtxEdge {
 		e.AddEdge(ctx)
 	}
@@ -340,7 +335,10 @@ func (ctx *context) ReportEvent(label Label, layer string, args ...interface{}) 
 // Create and report an event using KVs from variadic args
 func (ctx *context) reportEvent(label Label, layer string, addCtxEdge bool, args ...interface{}) error {
 	// create new event from context
-	e := ctx.NewEvent(label, layer)
+	e, err := ctx.NewEvent(label, layer)
+	if err != nil { // error creating event (e.g. couldn't init random IDs)
+		return err
+	}
 	return ctx.report(e, addCtxEdge, args...)
 }
 

--- a/v1/tv/internal/traceview/context_test.go
+++ b/v1/tv/internal/traceview/context_test.go
@@ -3,6 +3,9 @@
 package traceview
 
 import (
+	"bytes"
+	"crypto/rand"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -16,9 +19,9 @@ func TestMetadata(t *testing.T) {
 	// oboe_metadata_random
 	var md1 oboeMetadata
 	var mdNil *oboeMetadata
-	assert.Equal(t, -1, oboeMetadataInit(nil))   // init nil md
+	assert.Panics(t, func() { mdNil.Init() })    // init nil md
 	assert.Error(t, mdNil.SetRandom())           // random nil md
-	assert.Equal(t, 0, oboeMetadataInit(&md1))   // init valid md
+	md1.Init()                                   // init valid md
 	assert.NoError(t, md1.SetRandom())           // make random md
 	md1Str := md1.String()                       // get string repr of md
 	t.Logf("md1: %s", md1Str)                    // log md string
@@ -37,7 +40,7 @@ func TestMetadata(t *testing.T) {
 
 	// oboe_metadata_unpack
 	var mdUnpack oboeMetadata
-	assert.Equal(t, 0, oboeMetadataInit(&mdUnpack))              // init new md
+	mdUnpack.Init()                                              // init new md
 	assert.Equal(t, -1, oboeMetadataUnpack(nil, buf))            // unpack valid buf into nil md
 	assert.Equal(t, -1, oboeMetadataUnpack(&mdUnpack, []byte{})) // unpack empty buf into md
 	assert.Equal(t, -1, oboeMetadataUnpack(&mdUnpack, buf[:8]))  // unpack truncated buf into md
@@ -48,10 +51,10 @@ func TestMetadata(t *testing.T) {
 	// oboe_metadata_pack for 12-byte shorter trace/task ID (default is 20 + 8-byte op ID)
 	shortTaskLen := 12
 	var mdS, mdSU oboeMetadata
-	assert.Equal(t, 0, oboeMetadataInit(&mdS)) // init regular metadata
-	mdS.taskLen = shortTaskLen                 // override task ID len
-	assert.NoError(t, mdS.SetRandom())         // generate random task & op IDs
-	bufS := make([]byte, 128)                  // buffer to pack
+	mdS.Init()                         // init regular metadata
+	mdS.taskLen = shortTaskLen         // override task ID len
+	assert.NoError(t, mdS.SetRandom()) // generate random task & op IDs
+	bufS := make([]byte, 128)          // buffer to pack
 	assert.Equal(t, (1 + shortTaskLen + 8),
 		oboeMetadataPack(&mdS, bufS)) // pack buf
 	mdSStr, err := oboeMetadataToString(&mdS) // encode as string
@@ -67,7 +70,7 @@ func TestMetadata(t *testing.T) {
 	var md2 oboeMetadata
 	nullMd := "1B00000000000000000000000000000000000000000000000000000000"
 	assert.NotEqual(t, md1Str, nullMd)                                // ensure md1 string is not null
-	assert.Equal(t, 0, oboeMetadataInit(&md2))                        // init empty md2
+	md2.Init()                                                        // init empty md2
 	assert.Equal(t, nullMd, md2.String())                             // empty md produceds null md string
 	assert.Equal(t, -1, oboeMetadataFromString(nil, md1Str))          // unpack str to nil md
 	assert.Equal(t, -1, oboeMetadataFromString(&md2, "1BA70"))        // load md2 from invalid str
@@ -93,15 +96,77 @@ func TestMetadata(t *testing.T) {
 	assert.Equal(t, s, md1Str)           // assert matches md1 str
 	assert.NoError(t, err)               // no error
 
-	// Context.String()
+	// context.String()
 	ctx := &context{md2}
 	assert.Equal(t, md1Str, ctx.String())
 	nctx := &nullContext{}
 	assert.Equal(t, "", nctx.String())
+
+	// context.Copy()
+	cctx := ctx.Copy().(*context)
+	t.Logf("mdCopy: %v", cctx.String())
+	assert.Equal(t, cctx.String(), ctx.String())
+	assert.True(t, bytes.Equal(cctx.metadata.ids.taskID, ctx.metadata.ids.taskID))
+	t.Logf("cctx opID %v", cctx.metadata.ids.opID)
+	t.Logf(" ctx opID %v", ctx.metadata.ids.opID)
+	assert.True(t, bytes.Equal(cctx.metadata.ids.opID, ctx.metadata.ids.opID))
+	assert.Equal(t, ctx.metadata.taskLen, cctx.metadata.taskLen)
+	assert.Equal(t, ctx.metadata.opLen, cctx.metadata.opLen)
+	assert.Equal(t, len(cctx.metadata.ids.taskID), cctx.metadata.taskLen)
+	assert.Equal(t, len(cctx.metadata.ids.opID), cctx.metadata.opLen)
+	assert.Equal(t, len(ctx.metadata.ids.taskID), ctx.metadata.taskLen)
+	assert.Equal(t, len(ctx.metadata.ids.opID), ctx.metadata.opLen)
+	assert.Equal(t, oboeMetadataStringLen, len(cctx.String()))
 }
 
+type errorReader struct {
+	failOn    map[int]bool
+	callCount int
+}
+
+func (r *errorReader) Read(p []byte) (n int, err error) {
+	// fail always, or on specified calls
+	r.callCount++
+	if r.failOn == nil || r.failOn[r.callCount-1] {
+		return 0, errors.New("rand error")
+	}
+	return rand.Read(p)
+}
+
+func TestMetadataRandom(t *testing.T) {
+	r := SetTestReporter()
+	// if RNG fails, don't report events/spans associated with RNG failures.
+	randReader = &errorReader{failOn: map[int]bool{0: true}}
+	ctx := newContext()
+	assert.IsType(t, &nullContext{}, ctx)
+	assert.Empty(t, r.Bufs) // no events reported
+
+	// RNG failure on second call (for metadata op ID)
+	randReader = &errorReader{failOn: map[int]bool{1: true}}
+	ctx2 := newContext()
+	assert.IsType(t, &nullContext{}, ctx2)
+	assert.Empty(t, r.Bufs) // no events reported
+
+	// RNG failure on third call (for event op ID)
+	randReader = &errorReader{failOn: map[int]bool{2: true}}
+	ctx3 := newContext()
+	assert.IsType(t, ctx3, &context{}) // context created successfully
+	e3 := ctx3.NewSampledEvent(LabelEntry, "randErrLayer", false)
+	assert.IsType(t, &nullEvent{}, e3)
+	assert.Empty(t, r.Bufs) // no events reported
+
+	// RNG failure on valid context while trying to report an event
+	randReader = &errorReader{failOn: map[int]bool{0: true}}
+	assert.Error(t, ctx3.(*context).reportEvent(LabelEntry, "randErrLayer", false))
+	assert.Empty(t, r.Bufs) // no events reported
+
+	randReader = rand.Reader // set back to normal
+}
+
+// newTestContext returns a fresh random *context with no events reported for use in unit tests.
 func newTestContext(t *testing.T) *context {
 	ctx := newContext()
+	assert.True(t, ctx.IsTracing())
 	assert.IsType(t, ctx, &context{})
 	return ctx.(*context)
 }
@@ -109,8 +174,9 @@ func newTestContext(t *testing.T) *context {
 func TestReportEventMap(t *testing.T) {
 	r := SetTestReporter()
 	ctx := newTestContext(t)
-	e := ctx.NewEvent(LabelEntry, "myLayer")
-	err := e.Report(ctx)
+	e, err := ctx.NewEvent(LabelEntry, "myLayer")
+	assert.NoError(t, err)
+	err = e.Report(ctx)
 	assert.NoError(t, err)
 
 	assert.NoError(t, ctx.ReportEventMap(LabelInfo, "myLayer", map[string]interface{}{
@@ -145,7 +211,8 @@ func TestNullContext(t *testing.T) {
 	assert.Len(t, r.Bufs, 0) // no reporting
 
 	// try and report a real unrelated event on a null context
-	e2 := newTestContext(t).NewEvent(LabelEntry, "e2")
+	e2, err := newTestContext(t).NewEvent(LabelEntry, "e2")
+	assert.NoError(t, err)
 	assert.NoError(t, e2.ReportContext(ctx, false))
 	assert.Len(t, r.Bufs, 0) // no reporting
 

--- a/v1/tv/internal/traceview/event.go
+++ b/v1/tv/internal/traceview/event.go
@@ -43,7 +43,9 @@ func oboeEventInit(evt *event, md *oboeMetadata) int {
 	evt.metadata.opLen = md.opLen
 
 	copy(evt.metadata.ids.taskID, md.ids.taskID)
-	oboeRandomOpID(&evt.metadata)
+	if err := evt.metadata.SetRandomOpID(); err != nil {
+		return -1
+	}
 
 	// Buffer initialization
 

--- a/v1/tv/internal/traceview/event_test.go
+++ b/v1/tv/internal/traceview/event_test.go
@@ -13,8 +13,7 @@ var testLayer = "go_test"
 
 func TestSendEvent(t *testing.T) {
 	r := SetTestReporter()
-
-	ctx := newContext()
+	ctx := newTestContext(t)
 	e := ctx.NewEvent(LabelEntry, testLayer)
 	e.AddInt("IntTest", 123)
 
@@ -47,10 +46,10 @@ func TestEvent(t *testing.T) {
 	// oboe_event_init
 	evt := &event{}
 	var md oboeMetadata
-	assert.Equal(t, -1, oboeEventInit(nil, nil))            // init nil evt, md
-	assert.Equal(t, -1, oboeEventInit(evt, nil))            // init evt, nil md
-	assert.Equal(t, 0, oboeMetadataInit(&md))               // init valid md
-	assert.NotPanics(t, func() { oboeMetadataRandom(&md) }) // make random md
+	assert.Equal(t, -1, oboeEventInit(nil, nil)) // init nil evt, md
+	assert.Equal(t, -1, oboeEventInit(evt, nil)) // init evt, nil md
+	assert.Equal(t, 0, oboeMetadataInit(&md))    // init valid md
+	assert.NoError(t, md.SetRandom())            // make random md
 	t.Logf("TestEvent md: %v", md.String())
 	assert.Equal(t, 0, oboeEventInit(evt, &md))                // init valid evt, md
 	assert.Equal(t, evt.metadata.ids.taskID, md.ids.taskID)    // task IDs should match
@@ -61,7 +60,7 @@ func TestEvent(t *testing.T) {
 func TestEventMetadata(t *testing.T) {
 	r := SetTestReporter()
 
-	ctx := newContext()
+	ctx := newTestContext(t)
 	e := ctx.NewEvent(LabelExit, "alice")
 	e2 := ctx.NewEvent(LabelEntry, "bob")
 
@@ -85,7 +84,7 @@ func TestEventMetadata(t *testing.T) {
 
 func TestSampledEvent(t *testing.T) {
 	r := SetTestReporter()
-	ctx := newContext()
+	ctx := newTestContext(t)
 	e := ctx.NewEvent(LabelEntry, testLayer)
 	err := e.Report(ctx)
 	assert.NoError(t, err)
@@ -100,7 +99,7 @@ func TestSampledEvent(t *testing.T) {
 }
 func TestSampledEventNoEdge(t *testing.T) {
 	r := SetTestReporter()
-	ctx := newContext()
+	ctx := newTestContext(t)
 	e := ctx.NewEvent(LabelEntry, testLayer)
 	err := e.Report(ctx)
 	assert.NoError(t, err)

--- a/v1/tv/internal/traceview/oboe.go
+++ b/v1/tv/internal/traceview/oboe.go
@@ -62,13 +62,15 @@ var initMessageOnce sync.Once
 
 func sendInitMessage() {
 	ctx := newContext()
-	ctx.reportEvent(LabelEntry, initLayer, false,
-		"__Init", 1,
-		"Go.Version", runtime.Version(),
-		"Go.Oboe.Version", initVersion,
-		"Oboe.Version", oboeVersion,
-	)
-	ctx.ReportEvent(LabelExit, initLayer)
+	if c, ok := ctx.(*context); ok {
+		c.reportEvent(LabelEntry, initLayer, false,
+			"__Init", 1,
+			"Go.Version", runtime.Version(),
+			"Go.Oboe.Version", initVersion,
+			"Oboe.Version", oboeVersion,
+		)
+		c.ReportEvent(LabelExit, initLayer)
+	}
 }
 
 func oboeSampleRequest(layer, xtrace_header string) (bool, int, int) {

--- a/v1/tv/internal/traceview/reporter.go
+++ b/v1/tv/internal/traceview/reporter.go
@@ -132,7 +132,7 @@ type TestReporter struct {
 	Bufs        [][]byte
 	ShouldTrace bool
 	ShouldError bool
-	ErrorEvents []bool // whether to drop an event
+	ErrorEvents map[int]bool // whether to drop an event
 	eventCount  int
 }
 
@@ -140,8 +140,7 @@ type TestReporter struct {
 func (r *TestReporter) WritePacket(buf []byte) (int, error) {
 	r.eventCount++
 	if r.ShouldError || // error all events
-		(len(r.ErrorEvents) != 0 && // error certain specified events
-			(r.eventCount-1) < len(r.ErrorEvents) && r.ErrorEvents[(r.eventCount-1)]) {
+		(r.ErrorEvents != nil && r.ErrorEvents[(r.eventCount-1)]) { // error certain specified events
 		return 0, errors.New("TestReporter error")
 	}
 	r.Bufs = append(r.Bufs, buf)

--- a/v1/tv/internal/traceview/reporter_test.go
+++ b/v1/tv/internal/traceview/reporter_test.go
@@ -46,7 +46,7 @@ func TestNullReporter(t *testing.T) {
 
 func TestNewReporter(t *testing.T) {
 	assert.IsType(t, &udpReporter{}, newReporter())
-
+	t.Logf("Forcing UDP listen error for invalid port 7777831")
 	reporterAddr = "127.0.0.1:777831"
 	assert.IsType(t, &nullReporter{}, newReporter())
 	reporterAddr = "127.0.0.1:7831"
@@ -60,14 +60,14 @@ func (h failHostnamer) Hostname() (string, error) {
 }
 func TestCacheHostname(t *testing.T) {
 	assert.IsType(t, &udpReporter{}, newReporter())
-
+	t.Logf("Forcing hostname error: 'Unable to get hostname' log message expected")
 	cacheHostname(failHostnamer{})
 	assert.IsType(t, &nullReporter{}, newReporter())
 }
 
 func TestReportEvent(t *testing.T) {
 	r := SetTestReporter()
-	ctx := newContext()
+	ctx := newTestContext(t)
 	assert.Error(t, reportEvent(r, ctx, nil))
 	assert.Len(t, r.Bufs, 0) // no reporting
 
@@ -76,7 +76,7 @@ func TestReportEvent(t *testing.T) {
 	assert.Error(t, reportEvent(r, nil, ev))
 	assert.Len(t, r.Bufs, 0) // no reporting
 
-	ctx2 := newContext()
+	ctx2 := newTestContext(t)
 	e2 := ctx2.NewEvent(LabelEntry, "layer2")
 	assert.Error(t, reportEvent(r, ctx2, ev))
 	assert.Error(t, reportEvent(r, ctx, e2))

--- a/v1/tv/internal/traceview/reporter_test.go
+++ b/v1/tv/internal/traceview/reporter_test.go
@@ -72,12 +72,14 @@ func TestReportEvent(t *testing.T) {
 	assert.Len(t, r.Bufs, 0) // no reporting
 
 	// mismatched task IDs
-	ev := ctx.NewEvent(LabelExit, testLayer)
+	ev, err := ctx.NewEvent(LabelExit, testLayer)
+	assert.NoError(t, err)
 	assert.Error(t, reportEvent(r, nil, ev))
 	assert.Len(t, r.Bufs, 0) // no reporting
 
 	ctx2 := newTestContext(t)
-	e2 := ctx2.NewEvent(LabelEntry, "layer2")
+	e2, err := ctx2.NewEvent(LabelEntry, "layer2")
+	assert.NoError(t, err)
 	assert.Error(t, reportEvent(r, ctx2, ev))
 	assert.Error(t, reportEvent(r, ctx, e2))
 

--- a/v1/tv/profile_test.go
+++ b/v1/tv/profile_test.go
@@ -71,7 +71,7 @@ func TestNoTraceBeginProfile(t *testing.T) {
 func TestTraceErrorBeginProfile(t *testing.T) {
 	// simulate reporter error on second event: prevents Layer from being reported
 	r := traceview.SetTestReporter()
-	r.ErrorEvents = []bool{false, true}
+	r.ErrorEvents = map[int]bool{1: true}
 	testProf(tv.NewContext(context.Background(), tv.NewTrace("testLayer")))
 	g.AssertGraph(t, r.Bufs, 1, map[g.MatchNode]g.AssertNode{
 		{"testLayer", "entry"}: {},
@@ -87,7 +87,7 @@ func TestNoTraceBeginLayerProfile(t *testing.T) {
 func TestTraceErrorBeginLayerProfile(t *testing.T) {
 	// simulate reporter error on second event: prevents nested Layer & Profile spans
 	r := traceview.SetTestReporter()
-	r.ErrorEvents = []bool{false, true}
+	r.ErrorEvents = map[int]bool{1: true}
 	testLayerProf(tv.NewContext(context.Background(), tv.NewTrace("testLayer")))
 	g.AssertGraph(t, r.Bufs, 2, map[g.MatchNode]g.AssertNode{
 		{"testLayer", "entry"}: {},

--- a/v1/tv/trace_test.go
+++ b/v1/tv/trace_test.go
@@ -133,6 +133,7 @@ func TestTraceExample(t *testing.T) {
 	r := traceview.SetTestReporter() // enable test reporter
 	// create a new trace, and a context to carry it around
 	ctx := tv.NewContext(context.Background(), tv.NewTrace("myExample"))
+	t.Logf("Reporting unrecognized event KV type")
 	traceExample(ctx) // generate events
 	assertTraceExample(t, r.Bufs)
 }
@@ -141,6 +142,7 @@ func TestTraceExampleCtx(t *testing.T) {
 	r := traceview.SetTestReporter() // enable test reporter
 	// create a new trace, and a context to carry it around
 	ctx := tv.NewContext(context.Background(), tv.NewTrace("myExample"))
+	t.Logf("Reporting unrecognized event KV type")
 	traceExampleCtx(ctx) // generate events
 	assertTraceExample(t, r.Bufs)
 }


### PR DESCRIPTION
Abstracting RNG to an io.Reader variable allows for testing failures of [rand.Read](https://golang.org/pkg/crypto/rand/#Read), the final blocker to 100% coverage!
Also provides test case & fix for length bug in metadata.Init() and context.Copy().