### PR TITLE
Improvements to v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,14 @@ func main() {
 ![sample_app screenshot](https://github.com/appneta/go-appneta/raw/master/img/readme-screenshot1.png)
 
 To monitor more than just the overall latency of each request to your Go service, you will need to
-break a request's processing time down by placing small benchmarks into your code.
+break a request's processing time down by placing small benchmarks into your code. To do so, first
+start or continue a `Trace` (the root `Layer`), then create a series of `Layer` spans (or `Profile`
+timings) to capture the time used by different parts of the app's stack as it is processed.
 
-To do so, first start or continue a `Trace` (the root `Layer`), then create a series of `Layer`
-spans (or `Profile` timings) to capture the time used by different parts of the app's stack as it is
-processed.
-
-TraceView provides two ways of measuring time spent by your code: a "Layer" span can measure e.g. a
-single DB query or cache request, an outgoing HTTP or RPC request, or the entire time spent within a
-controller method.
-
-A `Profile` provides a named measurement of time spent inside a `Layer`, and is typically used to
+TraceView provides two ways of measuring time spent by your code: a `Layer` can measure e.g. a
+single DB query or cache request, an outgoing HTTP or RPC request, the entire time spent within a
+controller method, or the time used by a middleware method between calls to child Layers. A
+`Profile` provides a named measurement of time spent inside a `Layer`, and is typically used to
 measure a single function call or code block, e.g. to represent the time used by expensive
 computation(s) occurring in a `Layer`. Layers can be created as children of other Layers, but a
 `Profile` cannot have children.

--- a/examples/distributed_app/.gitignore
+++ b/examples/distributed_app/.gitignore
@@ -1,0 +1,2 @@
+distributed_app
+bob/bob

--- a/examples/distributed_app/main.go
+++ b/examples/distributed_app/main.go
@@ -19,12 +19,12 @@ func aliceHandler(w http.ResponseWriter, r *http.Request) {
 
 	// call an HTTP endpoint and propagate the distributed trace context
 	url := "http://127.0.0.1:8891/bob"
-	// begin layer for the client side of the HTTP service request
-	l := tv.BeginHTTPClientLayer(ctx, r)
 
 	// create HTTP client and set trace metadata header
 	httpClient := &http.Client{}
 	httpReq, _ := http.NewRequest("GET", url, nil)
+	// begin layer for the client side of the HTTP service request
+	l := tv.BeginHTTPClientLayer(ctx, httpReq)
 
 	// make HTTP request to external API
 	resp, err := httpClient.Do(httpReq)

--- a/examples/sample_app/Dockerfile
+++ b/examples/sample_app/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.6
+
+# Install AppNeta package dependencies and agent.
+# http://www.appneta.com/products/traceview/
+# requires key arg, e.g.: docker build --build-arg accesskey=TRACEVIEW_KEY .
+RUN apt-get -y install wget
+ARG accesskey
+RUN wget https://files.appneta.com/install_appneta.sh
+RUN bash ./install_appneta.sh $accesskey
+RUN service tracelyzer start
+
+# Based on Go 1.6-onbuild Dockerfile
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+COPY . /go/src/app
+RUN go-wrapper download -tags traceview
+RUN go-wrapper install -tags traceview
+
+# Start tracelyzer agent running alongside app, following:
+#  https://docs.appneta.com/install-instrumentation#traceview--docker
+# Example running agent in a separate container: https://github.com/tlunter/tracelytics-docker
+CMD service tracelyzer start & /go/bin/app -testClients true -addr :8899
+EXPOSE 8899

--- a/examples/sample_app/main.go
+++ b/examples/sample_app/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/appneta/go-appneta/v1/tv"
@@ -48,8 +49,8 @@ func init() {
 	flag.BoolVar(&testClients, "testClients", false, "run test clients")
 	flag.Parse()
 	if testClients {
-		go doForever("GET", "http://localhost:8899/slow")
-		go doForever("POST", "http://localhost:8899/slowly")
+		go doForever("GET", fmt.Sprintf("http://localhost%s/slow", addr))
+		go doForever("POST", fmt.Sprintf("http://localhost%s/slowly", addr))
 	}
 }
 

--- a/v1/tv/context.go
+++ b/v1/tv/context.go
@@ -34,7 +34,7 @@ func fromContext(ctx context.Context) (l Layer, ok bool) {
 func TraceFromContext(ctx context.Context) Trace {
 	t, ok := traceFromContext(ctx)
 	if !ok {
-		return nullTrace{}
+		return &nullTrace{}
 	}
 	return t
 }

--- a/v1/tv/context.go
+++ b/v1/tv/context.go
@@ -21,7 +21,7 @@ func newLayerContext(ctx context.Context, l Layer) context.Context {
 func FromContext(ctx context.Context) Layer {
 	l, ok := fromContext(ctx)
 	if !ok {
-		return &nullSpan{}
+		return nullSpan{}
 	}
 	return l
 }
@@ -34,7 +34,7 @@ func fromContext(ctx context.Context) (l Layer, ok bool) {
 func TraceFromContext(ctx context.Context) Trace {
 	t, ok := traceFromContext(ctx)
 	if !ok {
-		return &nullTrace{}
+		return nullTrace{}
 	}
 	return t
 }

--- a/v1/tv/context.go
+++ b/v1/tv/context.go
@@ -4,8 +4,10 @@ package tv
 
 import "golang.org/x/net/context"
 
-var contextKey = "github.com/appneta/go-appneta/v1/tv.Trace"
-var contextLayerKey = "github.com/appneta/go-appneta/v1/tv.Layer"
+type contextKeyT string
+
+var contextKey = contextKeyT("github.com/appneta/go-appneta/v1/tv.Trace")
+var contextLayerKey = contextKeyT("github.com/appneta/go-appneta/v1/tv.Layer")
 
 // NewContext returns a copy of the parent context and associates it with a Trace.
 func NewContext(ctx context.Context, t Trace) context.Context {

--- a/v1/tv/context.go
+++ b/v1/tv/context.go
@@ -21,7 +21,7 @@ func newLayerContext(ctx context.Context, l Layer) context.Context {
 func FromContext(ctx context.Context) Layer {
 	l, ok := fromContext(ctx)
 	if !ok {
-		return nullSpan{}
+		return &nullSpan{}
 	}
 	return l
 }

--- a/v1/tv/context_test.go
+++ b/v1/tv/context_test.go
@@ -78,8 +78,8 @@ func TestNullSpan(t *testing.T) {
 	c1.addProfile(p1)
 
 	nctx := c1.tvContext()
-	assert.Equal(t, reflect.TypeOf(nctx).Name(), "nullContext")
-	assert.IsType(t, reflect.TypeOf(nctx.Copy()).Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(nctx).Elem().Name(), "nullContext")
+	assert.IsType(t, reflect.TypeOf(nctx.Copy()).Elem().Name(), "nullContext")
 
 	g.AssertGraph(t, r.Bufs, 3, map[g.MatchNode]g.AssertNode{
 		{"TestNullSpan", "entry"}: {},

--- a/v1/tv/context_test.go
+++ b/v1/tv/context_test.go
@@ -70,7 +70,7 @@ func TestNullSpan(t *testing.T) {
 	p1.End()
 
 	c1 := l1.BeginLayer("C1") // child after parent ended
-	assert.IsType(t, c1, nullSpan{})
+	assert.IsType(t, c1, &nullSpan{})
 	assert.False(t, c1.IsTracing())
 	assert.False(t, c1.ok())
 	assert.Empty(t, c1.MetadataString())

--- a/v1/tv/context_test.go
+++ b/v1/tv/context_test.go
@@ -70,7 +70,7 @@ func TestNullSpan(t *testing.T) {
 	p1.End()
 
 	c1 := l1.BeginLayer("C1") // child after parent ended
-	assert.IsType(t, c1, &nullSpan{})
+	assert.IsType(t, c1, nullSpan{})
 	assert.False(t, c1.IsTracing())
 	assert.False(t, c1.ok())
 	assert.Empty(t, c1.MetadataString())
@@ -78,8 +78,8 @@ func TestNullSpan(t *testing.T) {
 	c1.addProfile(p1)
 
 	nctx := c1.tvContext()
-	assert.Equal(t, reflect.TypeOf(nctx).Elem().Name(), "nullContext")
-	assert.IsType(t, reflect.TypeOf(nctx.Copy()).Elem().Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(nctx).Name(), "nullContext")
+	assert.IsType(t, reflect.TypeOf(nctx.Copy()).Name(), "nullContext")
 
 	g.AssertGraph(t, r.Bufs, 3, map[g.MatchNode]g.AssertNode{
 		{"TestNullSpan", "entry"}: {},

--- a/v1/tv/http_client_instrumentation.go
+++ b/v1/tv/http_client_instrumentation.go
@@ -26,7 +26,7 @@ type HTTPClientLayer struct{ Layer }
 func BeginHTTPClientLayer(ctx context.Context, r *http.Request) HTTPClientLayer {
 	if r != nil {
 		l := BeginRemoteURLLayer(ctx, "http.Client", r.URL.String())
-		r.Header.Set("X-Trace", l.MetadataString())
+		r.Header.Set(HTTPHeaderName, l.MetadataString())
 		return HTTPClientLayer{Layer: l}
 	}
 	return HTTPClientLayer{Layer: &nullSpan{}}
@@ -42,7 +42,7 @@ func (l HTTPClientLayer) AddHTTPResponse(r *http.Response, err error) {
 		}
 		if r != nil {
 			l.AddEndArgs("RemoteStatus", r.StatusCode, "ContentLength", r.ContentLength)
-			if md := r.Header.Get("X-Trace"); md != "" {
+			if md := r.Header.Get(HTTPHeaderName); md != "" {
 				l.AddEndArgs("Edge", md)
 			}
 		}

--- a/v1/tv/http_client_instrumentation.go
+++ b/v1/tv/http_client_instrumentation.go
@@ -29,7 +29,7 @@ func BeginHTTPClientLayer(ctx context.Context, r *http.Request) HTTPClientLayer 
 		r.Header.Set("X-Trace", l.MetadataString())
 		return HTTPClientLayer{Layer: l}
 	}
-	return HTTPClientLayer{Layer: nullSpan{}}
+	return HTTPClientLayer{Layer: &nullSpan{}}
 }
 
 // AddHTTPResponse adds information from http.Response to this layer. It will also check the HTTP

--- a/v1/tv/http_client_instrumentation.go
+++ b/v1/tv/http_client_instrumentation.go
@@ -29,7 +29,7 @@ func BeginHTTPClientLayer(ctx context.Context, r *http.Request) HTTPClientLayer 
 		r.Header.Set("X-Trace", l.MetadataString())
 		return HTTPClientLayer{Layer: l}
 	}
-	return HTTPClientLayer{Layer: &nullSpan{}}
+	return HTTPClientLayer{Layer: nullSpan{}}
 }
 
 // AddHTTPResponse adds information from http.Response to this layer. It will also check the HTTP

--- a/v1/tv/http_instrumentation.go
+++ b/v1/tv/http_instrumentation.go
@@ -12,8 +12,9 @@ import (
 
 var httpHandlerLayerName = "http.HandlerFunc"
 
-// HTTPHandler wraps an http handler function with entry / exit events,
-// returning a new function that can be used in its place.
+// HTTPHandler wraps an http.HandlerFunc with entry / exit events,
+// returning a new handler that can be used in its place.
+//   http.HandleFunc("/path", tv.HTTPHandler(myHandler))
 func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
 	// At wrap time (when binding handler to router): get name of wrapped handler func
 	var endArgs []interface{}
@@ -34,9 +35,15 @@ func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 }
 
 // TraceFromHTTPRequestResponse returns a Trace and a wrapped http.ResponseWriter, given a
-// http.ResponseWriter and http.Request. If a distributed trace is described in the "X-Trace"
-// header, this context will be continued. The returned http.ResponseWriter should be used in place
-// of the one passed into this function in order to observe the response's headers and status code.
+// http.ResponseWriter and http.Request. If a distributed trace is described in the HTTP request
+// headers, the trace's context will be continued. The returned http.ResponseWriter should be used
+// in place of the one passed into this function in order to observe the response's headers and
+// status code.
+//   func myHandler(w http.ResponseWriter, r *http.Request) {
+//       tr, w := tv.TraceFromHTTPRequestResponse("myHandler", w, r)
+//       defer tr.End()
+//       // ...
+//   }
 func TraceFromHTTPRequestResponse(layerName string, w http.ResponseWriter, r *http.Request) (Trace, http.ResponseWriter) {
 	t := traceFromHTTPRequest(layerName, r)
 	wrapper := newResponseWriter(w, t) // wrap writer with response-observing writer

--- a/v1/tv/http_instrumentation.go
+++ b/v1/tv/http_instrumentation.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-var httpHandlerLayerName = "http.HandlerFunc"
+// HTTPHeaderName is a constant for the HTTP header used by TraceView ("X-Trace") to propagate
+// the distributed tracing context across HTTP requests.
+const HTTPHeaderName = "X-Trace"
+const httpHandlerLayerName = "http.HandlerFunc"
 
 // HTTPHandler wraps an http.HandlerFunc with entry / exit events,
 // returning a new handler that can be used in its place.
@@ -59,14 +62,14 @@ type httpResponseWriter struct {
 }
 
 func (w *httpResponseWriter) WriteHeader(status int) {
-	w.Status = status               // observe HTTP status code
-	md := w.Header().Get("X-Trace") // check response for downstream metadata
-	if w.t.IsTracing() {            // set trace exit metadata in X-Trace header
+	w.Status = status                    // observe HTTP status code
+	md := w.Header().Get(HTTPHeaderName) // check response for downstream metadata
+	if w.t.IsTracing() {                 // set trace exit metadata in X-Trace header
 		// if downstream response headers mention a different layer, add edge to it
 		if md != "" && md != w.t.ExitMetadata() {
 			w.t.AddEndArgs("Edge", md)
 		}
-		w.Header().Set("X-Trace", w.t.ExitMetadata()) // replace downstream MD with ours
+		w.Header().Set(HTTPHeaderName, w.t.ExitMetadata()) // replace downstream MD with ours
 	}
 	w.ResponseWriter.WriteHeader(status)
 }
@@ -79,7 +82,7 @@ func newResponseWriter(writer http.ResponseWriter, t Trace) *httpResponseWriter 
 	// add exit event metadata to X-Trace header
 	if t.IsTracing() {
 		// add/replace response header metadata with this trace's
-		w.Header().Set("X-Trace", t.ExitMetadata())
+		w.Header().Set(HTTPHeaderName, t.ExitMetadata())
 	}
 	return w
 }
@@ -88,7 +91,7 @@ func newResponseWriter(writer http.ResponseWriter, t Trace) *httpResponseWriter 
 // in the "X-Trace" header, this context will be continued.
 func traceFromHTTPRequest(layerName string, r *http.Request) Trace {
 	// start trace, passing in metadata header
-	t := NewTraceFromID(layerName, r.Header.Get("X-Trace"), func() KVMap {
+	t := NewTraceFromID(layerName, r.Header.Get(HTTPHeaderName), func() KVMap {
 		return KVMap{
 			"Method":       r.Method,
 			"HTTP-Host":    r.Host,
@@ -98,6 +101,6 @@ func traceFromHTTPRequest(layerName string, r *http.Request) Trace {
 		}
 	})
 	// update incoming metadata in request headers for any downstream readers
-	r.Header.Set("X-Trace", t.MetadataString())
+	r.Header.Set(HTTPHeaderName, t.MetadataString())
 	return t
 }

--- a/v1/tv/http_instrumentation_test.go
+++ b/v1/tv/http_instrumentation_test.go
@@ -87,9 +87,9 @@ func TestHTTPHandlerNoTrace(t *testing.T) {
 
 // testServer tests creating a layer/trace from inside an HTTP handler (using tv.TraceFromHTTPRequest)
 func testServer(t *testing.T, list net.Listener) {
-	s := &http.Server{Handler: http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+	s := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// create layer from incoming HTTP Request headers, if trace exists
-		tr, w := tv.TraceFromHTTPRequestResponse("myHandler", writer, req)
+		tr, w := tv.TraceFromHTTPRequestResponse("myHandler", w, req)
 		defer tr.End()
 
 		tr.AddEndArgs("NotReported") // odd-length args, should have no effect

--- a/v1/tv/internal/graphtest/graph.go
+++ b/v1/tv/internal/graphtest/graph.go
@@ -84,6 +84,7 @@ type AssertNode struct { // run to assert each Node
 }
 
 var checkedEdges = 0
+var checkedNodes = 0
 
 // AssertGraph builds a graph from encoded events and asserts out-edges for each node in nodeMap.
 func AssertGraph(t *testing.T, bufs [][]byte, numNodes int, nodeMap map[MatchNode]AssertNode) {
@@ -106,12 +107,13 @@ func AssertGraph(t *testing.T, bufs [][]byte, numNodes int, nodeMap map[MatchNod
 		// assert each node seen once
 		assert.False(t, seen[m])
 		seen[m] = true
+		checkedNodes++
 	}
 	for m, a := range nodeMap {
 		assert.True(t, seen[m], "Didn't see node %v edges %v", m, a)
 	}
 
-	t.Logf("Total %d edges checked", checkedEdges)
+	t.Logf("Total %d nodes, %d edges checked", checkedNodes, checkedEdges)
 
 	if os.Getenv("DOT_GRAPHS") != "" { // save graph to file named for caller
 		var pc uintptr

--- a/v1/tv/internal/traceview/bson.go
+++ b/v1/tv/internal/traceview/bson.go
@@ -2,9 +2,7 @@
 
 package traceview
 
-import (
-	"math"
-)
+import "math"
 
 type bsonBuffer struct {
 	buf []byte
@@ -65,13 +63,13 @@ func bsonAppendBool(b *bsonBuffer, k string, v bool) {
 }
 
 func bsonAppendStartArray(b *bsonBuffer, k string) (start int) {
-	start = len(b.buf)
 	b.addElemName('\x04', k)
+	start = b.reserveInt32()
 	return
 }
 func bsonAppendStartObject(b *bsonBuffer, k string) (start int) {
-	start = len(b.buf)
 	b.addElemName('\x03', k)
+	start = b.reserveInt32()
 	return
 }
 func bsonAppendFinishObject(b *bsonBuffer, start int) {

--- a/v1/tv/internal/traceview/bson.go
+++ b/v1/tv/internal/traceview/bson.go
@@ -64,6 +64,21 @@ func bsonAppendBool(b *bsonBuffer, k string, v bool) {
 	}
 }
 
+func bsonAppendStartArray(b *bsonBuffer, k string) (start int) {
+	start = len(b.buf)
+	b.addElemName('\x04', k)
+	return
+}
+func bsonAppendStartObject(b *bsonBuffer, k string) (start int) {
+	start = len(b.buf)
+	b.addElemName('\x03', k)
+	return
+}
+func bsonAppendFinishObject(b *bsonBuffer, start int) {
+	b.addBytes(0)
+	b.setInt32(start, int32(len(b.buf)-start))
+}
+
 // Based on https://github.com/go-mgo/mgo/blob/v2/bson/encode.go
 // --------------------------------------------------------------------------
 // Marshaling of elements in a document.

--- a/v1/tv/internal/traceview/bson.go
+++ b/v1/tv/internal/traceview/bson.go
@@ -62,16 +62,12 @@ func bsonAppendBool(b *bsonBuffer, k string, v bool) {
 	}
 }
 
-func bsonAppendStartArray(b *bsonBuffer, k string) (start int) {
-	b.addElemName('\x04', k)
-	start = b.reserveInt32()
-	return
-}
 func bsonAppendStartObject(b *bsonBuffer, k string) (start int) {
 	b.addElemName('\x03', k)
 	start = b.reserveInt32()
 	return
 }
+
 func bsonAppendFinishObject(b *bsonBuffer, start int) {
 	b.addBytes(0)
 	b.setInt32(start, int32(len(b.buf)-start))

--- a/v1/tv/internal/traceview/context.go
+++ b/v1/tv/internal/traceview/context.go
@@ -235,21 +235,21 @@ type Event interface {
 type nullContext struct{}
 type nullEvent struct{}
 
-func (e nullContext) ReportEvent(label Label, layer string, args ...interface{}) error {
+func (e *nullContext) ReportEvent(label Label, layer string, args ...interface{}) error {
 	return nil
 }
-func (e nullContext) ReportEventMap(label Label, layer string, keys map[string]interface{}) error {
+func (e *nullContext) ReportEventMap(label Label, layer string, keys map[string]interface{}) error {
 	return nil
 }
-func (e nullContext) Copy() Context                                         { return nullContext{} }
-func (e nullContext) IsTracing() bool                                       { return false }
-func (e nullContext) MetadataString() string                                { return "" }
-func (e nullContext) NewEvent(l Label, y string, g bool) Event              { return nullEvent{} }
+func (e *nullContext) Copy() Context                                        { return &nullContext{} }
+func (e *nullContext) IsTracing() bool                                      { return false }
+func (e *nullContext) MetadataString() string                               { return "" }
+func (e *nullContext) NewEvent(l Label, y string, g bool) Event             { return nullEvent{} }
 func (e nullEvent) ReportContext(c Context, g bool, a ...interface{}) error { return nil }
 func (e nullEvent) MetadataString() string                                  { return "" }
 
 // NewNullContext returns a context that is not tracing.
-func NewNullContext() Context { return nullContext{} }
+func NewNullContext() Context { return &nullContext{} }
 
 // newContext allocates a context with random metadata (for a new trace).
 func newContext() Context {
@@ -259,7 +259,7 @@ func newContext() Context {
 		if debugLog {
 			log.Printf("TraceView rand.Read error: %v", err)
 		}
-		return nullContext{}
+		return &nullContext{}
 	}
 	return ctx
 }
@@ -279,7 +279,7 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 		if mdStr != "" {
 			var err error
 			if ctx, err = newContextFromMetadataString(mdStr); err != nil {
-				return nullContext{}, false // bad incoming MD: no trace
+				return &nullContext{}, false // bad incoming MD: no trace
 			}
 			addCtxEdge = true
 		} else {
@@ -296,11 +296,11 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 			kvs["SampleRate"] = rate
 			kvs["SampleSource"] = source
 			if err := ctx.(*oboeContext).reportEventMap(LabelEntry, layer, addCtxEdge, kvs); err != nil {
-				return nullContext{}, false
+				return &nullContext{}, false
 			}
 		}
 	} else {
-		return nullContext{}, false
+		return &nullContext{}, false
 	}
 	return ctx, true
 }

--- a/v1/tv/internal/traceview/context.go
+++ b/v1/tv/internal/traceview/context.go
@@ -235,21 +235,21 @@ type Event interface {
 type nullContext struct{}
 type nullEvent struct{}
 
-func (e *nullContext) ReportEvent(label Label, layer string, args ...interface{}) error {
+func (e nullContext) ReportEvent(label Label, layer string, args ...interface{}) error {
 	return nil
 }
-func (e *nullContext) ReportEventMap(label Label, layer string, keys map[string]interface{}) error {
+func (e nullContext) ReportEventMap(label Label, layer string, keys map[string]interface{}) error {
 	return nil
 }
-func (e *nullContext) Copy() Context                                         { return &nullContext{} }
-func (e *nullContext) IsTracing() bool                                       { return false }
-func (e *nullContext) MetadataString() string                                { return "" }
-func (e *nullContext) NewEvent(l Label, y string, g bool) Event              { return &nullEvent{} }
-func (e *nullEvent) ReportContext(c Context, g bool, a ...interface{}) error { return nil }
-func (e *nullEvent) MetadataString() string                                  { return "" }
+func (e nullContext) Copy() Context                                         { return nullContext{} }
+func (e nullContext) IsTracing() bool                                       { return false }
+func (e nullContext) MetadataString() string                                { return "" }
+func (e nullContext) NewEvent(l Label, y string, g bool) Event              { return nullEvent{} }
+func (e nullEvent) ReportContext(c Context, g bool, a ...interface{}) error { return nil }
+func (e nullEvent) MetadataString() string                                  { return "" }
 
 // NewNullContext returns a context that is not tracing.
-func NewNullContext() Context { return &nullContext{} }
+func NewNullContext() Context { return nullContext{} }
 
 // newContext allocates a context with random metadata (for a new trace).
 func newContext() Context {
@@ -259,7 +259,7 @@ func newContext() Context {
 		if debugLog {
 			log.Printf("TraceView rand.Read error: %v", err)
 		}
-		return &nullContext{}
+		return nullContext{}
 	}
 	return ctx
 }
@@ -279,7 +279,7 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 		if mdStr != "" {
 			var err error
 			if ctx, err = newContextFromMetadataString(mdStr); err != nil {
-				return &nullContext{}, false // bad incoming MD: no trace
+				return nullContext{}, false // bad incoming MD: no trace
 			}
 			addCtxEdge = true
 		} else {
@@ -296,11 +296,11 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 			kvs["SampleRate"] = rate
 			kvs["SampleSource"] = source
 			if err := ctx.(*oboeContext).reportEventMap(LabelEntry, layer, addCtxEdge, kvs); err != nil {
-				return &nullContext{}, false
+				return nullContext{}, false
 			}
 		}
 	} else {
-		return &nullContext{}, false
+		return nullContext{}, false
 	}
 	return ctx, true
 }
@@ -321,7 +321,7 @@ func (ctx *oboeContext) newEvent(label Label, layer string) (*event, error) {
 func (ctx *oboeContext) NewEvent(label Label, layer string, addCtxEdge bool) Event {
 	e, err := newEvent(&ctx.metadata, label, layer)
 	if err != nil {
-		return &nullEvent{}
+		return nullEvent{}
 	}
 	if addCtxEdge {
 		e.AddEdge(ctx)

--- a/v1/tv/internal/traceview/context.go
+++ b/v1/tv/internal/traceview/context.go
@@ -241,12 +241,12 @@ func (e *nullContext) ReportEvent(label Label, layer string, args ...interface{}
 func (e *nullContext) ReportEventMap(label Label, layer string, keys map[string]interface{}) error {
 	return nil
 }
-func (e *nullContext) Copy() Context                                        { return &nullContext{} }
-func (e *nullContext) IsTracing() bool                                      { return false }
-func (e *nullContext) MetadataString() string                               { return "" }
-func (e *nullContext) NewEvent(l Label, y string, g bool) Event             { return nullEvent{} }
-func (e nullEvent) ReportContext(c Context, g bool, a ...interface{}) error { return nil }
-func (e nullEvent) MetadataString() string                                  { return "" }
+func (e *nullContext) Copy() Context                                         { return &nullContext{} }
+func (e *nullContext) IsTracing() bool                                       { return false }
+func (e *nullContext) MetadataString() string                                { return "" }
+func (e *nullContext) NewEvent(l Label, y string, g bool) Event              { return &nullEvent{} }
+func (e *nullEvent) ReportContext(c Context, g bool, a ...interface{}) error { return nil }
+func (e *nullEvent) MetadataString() string                                  { return "" }
 
 // NewNullContext returns a context that is not tracing.
 func NewNullContext() Context { return &nullContext{} }
@@ -321,7 +321,7 @@ func (ctx *oboeContext) newEvent(label Label, layer string) (*event, error) {
 func (ctx *oboeContext) NewEvent(label Label, layer string, addCtxEdge bool) Event {
 	e, err := newEvent(&ctx.metadata, label, layer)
 	if err != nil {
-		return nullEvent{}
+		return &nullEvent{}
 	}
 	if addCtxEdge {
 		e.AddEdge(ctx)

--- a/v1/tv/internal/traceview/context_test.go
+++ b/v1/tv/internal/traceview/context_test.go
@@ -112,7 +112,7 @@ func TestMetadata(t *testing.T) {
 	// context.String()
 	ctx := &oboeContext{md2}
 	assert.Equal(t, md1Str, ctx.MetadataString())
-	nctx := &nullContext{}
+	nctx := nullContext{}
 	assert.Equal(t, "", nctx.MetadataString())
 
 	// context.Copy()
@@ -151,13 +151,13 @@ func TestMetadataRandom(t *testing.T) {
 	// if RNG fails, don't report events/spans associated with RNG failures.
 	randReader = &errorReader{failOn: map[int]bool{0: true}}
 	ctx := newContext()
-	assert.IsType(t, &nullContext{}, ctx)
+	assert.IsType(t, nullContext{}, ctx)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on second call (for metadata op ID)
 	randReader = &errorReader{failOn: map[int]bool{1: true}}
 	ctx2 := newContext()
-	assert.IsType(t, &nullContext{}, ctx2)
+	assert.IsType(t, nullContext{}, ctx2)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on third call (for event op ID)
@@ -165,7 +165,7 @@ func TestMetadataRandom(t *testing.T) {
 	ctx3 := newContext()
 	assert.IsType(t, ctx3, &oboeContext{}) // context created successfully
 	e3 := ctx3.NewEvent(LabelEntry, "randErrLayer", false)
-	assert.IsType(t, &nullEvent{}, e3)
+	assert.IsType(t, nullEvent{}, e3)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on valid context while trying to report an event
@@ -210,7 +210,7 @@ func TestNewContext(t *testing.T) {
 	r.ShouldTrace = true
 	ctx, ok := NewContext("testBadMd", "hello", true, nil) // test invalid metadata string
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctx).Name(), "nullContext")
 	assert.Len(t, r.Bufs, 0) // no reporting
 }
 
@@ -220,7 +220,7 @@ func TestNullContext(t *testing.T) {
 
 	ctx, ok := NewContext("testLayer", "", false, nil) // nullContext{}
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctx).Name(), "nullContext")
 	assert.False(t, ctx.IsTracing())
 	assert.Empty(t, ctx.MetadataString())
 	assert.False(t, ctx.Copy().IsTracing())
@@ -244,7 +244,7 @@ func TestNullContext(t *testing.T) {
 	r.ShouldError = true
 	ctxBad, ok := NewContext("testBadEntry", "", true, nil)
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctxBad).Elem().Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctxBad).Name(), "nullContext")
 
 	assert.Len(t, r.Bufs, 0) // no reporting
 }

--- a/v1/tv/internal/traceview/context_test.go
+++ b/v1/tv/internal/traceview/context_test.go
@@ -165,7 +165,7 @@ func TestMetadataRandom(t *testing.T) {
 	ctx3 := newContext()
 	assert.IsType(t, ctx3, &oboeContext{}) // context created successfully
 	e3 := ctx3.NewEvent(LabelEntry, "randErrLayer", false)
-	assert.IsType(t, nullEvent{}, e3)
+	assert.IsType(t, &nullEvent{}, e3)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on valid context while trying to report an event

--- a/v1/tv/internal/traceview/context_test.go
+++ b/v1/tv/internal/traceview/context_test.go
@@ -112,7 +112,7 @@ func TestMetadata(t *testing.T) {
 	// context.String()
 	ctx := &oboeContext{md2}
 	assert.Equal(t, md1Str, ctx.MetadataString())
-	nctx := nullContext{}
+	nctx := &nullContext{}
 	assert.Equal(t, "", nctx.MetadataString())
 
 	// context.Copy()
@@ -151,13 +151,13 @@ func TestMetadataRandom(t *testing.T) {
 	// if RNG fails, don't report events/spans associated with RNG failures.
 	randReader = &errorReader{failOn: map[int]bool{0: true}}
 	ctx := newContext()
-	assert.IsType(t, nullContext{}, ctx)
+	assert.IsType(t, &nullContext{}, ctx)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on second call (for metadata op ID)
 	randReader = &errorReader{failOn: map[int]bool{1: true}}
 	ctx2 := newContext()
-	assert.IsType(t, nullContext{}, ctx2)
+	assert.IsType(t, &nullContext{}, ctx2)
 	assert.Empty(t, r.Bufs) // no events reported
 
 	// RNG failure on third call (for event op ID)
@@ -210,7 +210,7 @@ func TestNewContext(t *testing.T) {
 	r.ShouldTrace = true
 	ctx, ok := NewContext("testBadMd", "hello", true, nil) // test invalid metadata string
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctx).Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "nullContext")
 	assert.Len(t, r.Bufs, 0) // no reporting
 }
 
@@ -220,7 +220,7 @@ func TestNullContext(t *testing.T) {
 
 	ctx, ok := NewContext("testLayer", "", false, nil) // nullContext{}
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctx).Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "nullContext")
 	assert.False(t, ctx.IsTracing())
 	assert.Empty(t, ctx.MetadataString())
 	assert.False(t, ctx.Copy().IsTracing())
@@ -244,7 +244,7 @@ func TestNullContext(t *testing.T) {
 	r.ShouldError = true
 	ctxBad, ok := NewContext("testBadEntry", "", true, nil)
 	assert.False(t, ok)
-	assert.Equal(t, reflect.TypeOf(ctxBad).Name(), "nullContext")
+	assert.Equal(t, reflect.TypeOf(ctxBad).Elem().Name(), "nullContext")
 
 	assert.Len(t, r.Bufs, 0) // no reporting
 }

--- a/v1/tv/internal/traceview/cstrcache.go
+++ b/v1/tv/internal/traceview/cstrcache.go
@@ -9,37 +9,42 @@ import (
 	"sync"
 )
 
-// Caches CStrings:
-// currently used for entry layer names to avoid repetitive malloc/free of the same string.
-// We intentionally do not free here.
+// Currently used for entry layer names to avoid repetitive malloc/free of the same string,
+// and to count per-layer metrics. We intentionally do not free here.
 type cStringCache struct {
-	m map[string]*C.char
+	m map[string]*cachedLayer
 	sync.RWMutex
+}
+type cachedLayer struct {
+	name    *C.char
+	counter *rateCounter
 }
 
 func newCStringCache() *cStringCache {
 	return &cStringCache{
-		m: make(map[string]*C.char),
+		m: make(map[string]*cachedLayer),
 	}
 }
 
 // Has looks for the existence of a string
-func (c *cStringCache) Has(str string) *C.char {
+func (c *cStringCache) Has(str string) *cachedLayer {
 	c.RLock()
 	defer c.RUnlock()
-	cstr := c.m[str]
-	return cstr
+	return c.m[str]
 }
 
 // Gets *C.char associated with a Go string
-func (c *cStringCache) Get(str string) *C.char {
-	cstr := c.Has(str)
-	if cstr == nil {
+func (c *cStringCache) Get(str string) *cachedLayer {
+	cl := c.Has(str)
+	if cl == nil {
 		// Not found, need to allocate:
 		c.Lock()
 		defer c.Unlock()
-		cstr = C.CString(str)
-		c.m[str] = cstr
+		c.m[str] = &cachedLayer{
+			name:    C.CString(str),
+			counter: newRateCounter(rateCounterDefaultRate, rateCounterDefaultSize),
+		}
+		cl = c.m[str]
 	}
-	return cstr
+	return cl
 }

--- a/v1/tv/internal/traceview/cstrcache.go
+++ b/v1/tv/internal/traceview/cstrcache.go
@@ -33,6 +33,16 @@ func (c *cStringCache) Has(str string) *cachedLayer {
 	return c.m[str]
 }
 
+// Keys returns a list of this cache's keys
+func (c *cStringCache) Keys() (keys []string) {
+	c.RLock()
+	defer c.RUnlock()
+	for k := range c.m {
+		keys = append(keys, k)
+	}
+	return
+}
+
 // Gets *C.char associated with a Go string
 func (c *cStringCache) Get(str string) *cachedLayer {
 	cl := c.Has(str)

--- a/v1/tv/internal/traceview/cstrcache.go
+++ b/v1/tv/internal/traceview/cstrcache.go
@@ -1,3 +1,5 @@
+// +build traceview
+
 // Copyright (C) 2016 AppNeta, Inc. All rights reserved.
 
 package traceview

--- a/v1/tv/internal/traceview/event.go
+++ b/v1/tv/internal/traceview/event.go
@@ -52,11 +52,9 @@ func oboeEventInit(evt *event, md *oboeMetadata) error {
 	}
 
 	// Buffer initialization
-
 	bsonBufferInit(&evt.bbuf)
 
 	// Copy header to buffer
-	// TODO errors?
 	bsonAppendString(&evt.bbuf, "_V", eventHeader)
 
 	// Pack metadata
@@ -234,7 +232,7 @@ func (e *event) ReportUsing(c *oboeContext, r reporter) error { return reportEve
 // Reports event using default (UDP) Reporter
 func (e *event) Report(c *oboeContext) error { return e.ReportUsing(c, globalReporter) }
 
-// Report event using SampledContext interface
+// Report event using Context interface
 func (e *event) ReportContext(c Context, addCtxEdge bool, args ...interface{}) error {
 	if ctx, ok := c.(*oboeContext); ok {
 		return ctx.report(e, addCtxEdge, args...)

--- a/v1/tv/internal/traceview/event_test.go
+++ b/v1/tv/internal/traceview/event_test.go
@@ -99,7 +99,7 @@ func TestSendEvent(t *testing.T) {
 	})
 }
 
-func TestEvent(t *testing.T) {
+func TestOboeEvent(t *testing.T) {
 	// oboe_event_init
 	evt := &event{}
 	var md, emptyMd oboeMetadata
@@ -142,14 +142,14 @@ func TestEventMetadata(t *testing.T) {
 	})
 }
 
-func TestSampledEvent(t *testing.T) {
+func TestEvent(t *testing.T) {
 	r := SetTestReporter()
 	ctx := newTestContext(t)
 	e, err := ctx.newEvent(LabelEntry, testLayer)
 	assert.NoError(t, err)
 	err = e.Report(ctx)
 	assert.NoError(t, err)
-	// create SampledEvent with edge to entry
+	// create Event with edge to entry
 	se := ctx.NewEvent(LabelExit, testLayer, true)
 	assert.NoError(t, se.ReportContext(ctx, false))
 
@@ -158,7 +158,7 @@ func TestSampledEvent(t *testing.T) {
 		{"go_test", "exit"}:  {g.OutEdges{{"go_test", "entry"}}, nil},
 	})
 }
-func TestSampledEventNoEdge(t *testing.T) {
+func TestEventNoEdge(t *testing.T) {
 	r := SetTestReporter()
 	ctx := newTestContext(t)
 	e, err := ctx.newEvent(LabelEntry, testLayer)

--- a/v1/tv/internal/traceview/oboe.go
+++ b/v1/tv/internal/traceview/oboe.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -216,15 +215,11 @@ func appendCount(e *event, counts map[string]*rateCounts, name string, f func(*r
 	if len(counts) == 0 {
 		return
 	}
-	var j, startArray, startObject int
-	startArray = bsonAppendStartArray(&e.bbuf, name)
 	for layer, c := range counts {
-		startObject = bsonAppendStartObject(&e.bbuf, strconv.Itoa(j))
-		j++
+		startObject := bsonAppendStartObject(&e.bbuf, name)
 		e.AddInt64(layer, f(c))
 		bsonAppendFinishObject(&e.bbuf, startObject)
 	}
-	bsonAppendFinishObject(&e.bbuf, startArray)
 }
 
 func oboeSampleRequest(layer, xtraceHeader string) (bool, int, int) {

--- a/v1/tv/internal/traceview/oboe_test.go
+++ b/v1/tv/internal/traceview/oboe_test.go
@@ -127,8 +127,8 @@ func startTestUDPListener(t *testing.T, bufs *[][]byte, numbufs int) {
 	}(numbufs)
 }
 
-func testLayerCount(count int64) []interface{} {
-	return []interface{}{bson.D{bson.DocElem{Name: testLayer, Value: count}}}
+func testLayerCount(count int64) interface{} {
+	return bson.D{bson.DocElem{Name: testLayer, Value: count}}
 }
 func TestRateSampleRequest(t *testing.T) {
 	var bufs [][]byte

--- a/v1/tv/internal/traceview/oboe_test.go
+++ b/v1/tv/internal/traceview/oboe_test.go
@@ -126,13 +126,14 @@ func TestRateSampleRequest(t *testing.T) {
 			sampled++
 		}
 	}
-	assert.Equal(t, sampled, 10)
+	assert.Equal(t, sampled, 3)
 	cl := layerCache.Get(testLayer)
 	assert.EqualValues(t, 1000, cl.counter.requested)
 	assert.EqualValues(t, 0, cl.counter.through)
 	assert.EqualValues(t, sampled, cl.counter.traced)
 	assert.True(t, cl.counter.sampled > 0)
 	assert.True(t, cl.counter.limited > 0)
+
 }
 
 func TestOboeTracingMode(t *testing.T) {
@@ -142,11 +143,11 @@ func TestOboeTracingMode(t *testing.T) {
 
 	os.Setenv("GO_TRACEVIEW_TRACING_MODE", "ALWAYS")
 	readEnvSettings()
-	assert.EqualValues(t, globalSettings.settings_cfg.tracing_mode, 1) // C.OBOE_TRACE_ALWAYS
+	assert.EqualValues(t, globalSettings.settingsCfg.tracing_mode, 1) // C.OBOE_TRACE_ALWAYS
 
 	os.Setenv("GO_TRACEVIEW_TRACING_MODE", "tHRoUgh")
 	readEnvSettings()
-	assert.EqualValues(t, globalSettings.settings_cfg.tracing_mode, 2) // C.OBOE_TRACE_THROUGH
+	assert.EqualValues(t, globalSettings.settingsCfg.tracing_mode, 2) // C.OBOE_TRACE_THROUGH
 	ok, _, _ := oboeSampleRequest("myLayer", "1BJKL")
 	assert.True(t, ok)
 	ok, _, _ = oboeSampleRequest("myLayer", "")
@@ -154,7 +155,7 @@ func TestOboeTracingMode(t *testing.T) {
 
 	os.Setenv("GO_TRACEVIEW_TRACING_MODE", "never")
 	readEnvSettings()
-	assert.EqualValues(t, globalSettings.settings_cfg.tracing_mode, 0) // C.OBOE_TRACE_NEVER
+	assert.EqualValues(t, globalSettings.settingsCfg.tracing_mode, 0) // C.OBOE_TRACE_NEVER
 	ok, _, _ = oboeSampleRequest("myLayer", "1BJKL")
 	assert.False(t, ok)
 	ok, _, _ = oboeSampleRequest("myLayer", "")
@@ -162,5 +163,5 @@ func TestOboeTracingMode(t *testing.T) {
 
 	os.Setenv("GO_TRACEVIEW_TRACING_MODE", "")
 	readEnvSettings()
-	assert.EqualValues(t, globalSettings.settings_cfg.tracing_mode, 1)
+	assert.EqualValues(t, globalSettings.settingsCfg.tracing_mode, 1)
 }

--- a/v1/tv/trace.go
+++ b/v1/tv/trace.go
@@ -49,7 +49,7 @@ func (t *tvTrace) tvContext() traceview.Context { return t.tvCtx }
 func NewTrace(layerName string) Trace {
 	ctx, ok := traceview.NewContext(layerName, "", true, nil)
 	if !ok {
-		return &nullTrace{}
+		return nullTrace{}
 	}
 	return &tvTrace{
 		layerSpan: layerSpan{span: span{tvCtx: ctx, labeler: layerLabeler{layerName}}},
@@ -67,7 +67,7 @@ func NewTraceFromID(layerName, mdstr string, cb func() KVMap) Trace {
 		return nil
 	})
 	if !ok {
-		return &nullTrace{}
+		return nullTrace{}
 	}
 	return &tvTrace{
 		layerSpan: layerSpan{span: span{tvCtx: ctx, labeler: layerLabeler{layerName}}},
@@ -130,5 +130,5 @@ func (t *tvTrace) ExitMetadata() (mdHex string) {
 // A nullTrace is not tracing.
 type nullTrace struct{ nullSpan }
 
-func (t *nullTrace) EndCallback(f func() KVMap) {}
-func (t *nullTrace) ExitMetadata() string       { return "" }
+func (t nullTrace) EndCallback(f func() KVMap) {}
+func (t nullTrace) ExitMetadata() string       { return "" }

--- a/v1/tv/trace.go
+++ b/v1/tv/trace.go
@@ -49,7 +49,7 @@ func (t *tvTrace) tvContext() traceview.Context { return t.tvCtx }
 func NewTrace(layerName string) Trace {
 	ctx, ok := traceview.NewContext(layerName, "", true, nil)
 	if !ok {
-		return nullTrace{}
+		return &nullTrace{}
 	}
 	return &tvTrace{
 		layerSpan: layerSpan{span: span{tvCtx: ctx, labeler: layerLabeler{layerName}}},
@@ -67,7 +67,7 @@ func NewTraceFromID(layerName, mdstr string, cb func() KVMap) Trace {
 		return nil
 	})
 	if !ok {
-		return nullTrace{}
+		return &nullTrace{}
 	}
 	return &tvTrace{
 		layerSpan: layerSpan{span: span{tvCtx: ctx, labeler: layerLabeler{layerName}}},
@@ -130,5 +130,5 @@ func (t *tvTrace) ExitMetadata() (mdHex string) {
 // A nullTrace is not tracing.
 type nullTrace struct{ nullSpan }
 
-func (t nullTrace) EndCallback(f func() KVMap) {}
-func (t nullTrace) ExitMetadata() string       { return "" }
+func (t *nullTrace) EndCallback(f func() KVMap) {}
+func (t *nullTrace) ExitMetadata() string       { return "" }

--- a/v1/tv/trace_test.go
+++ b/v1/tv/trace_test.go
@@ -29,7 +29,7 @@ func TestTraceMetadata(t *testing.T) {
 		{"test", "entry"}: {},
 		{"test", "exit"}: {g.OutEdges{{"test", "entry"}}, func(n g.Node) {
 			// exit event should match ExitMetadata
-			assert.Equal(t, md, n.Map["X-Trace"])
+			assert.Equal(t, md, n.Map[tv.HTTPHeaderName])
 		}},
 	})
 }
@@ -284,12 +284,12 @@ func TestTraceFromMetadata(t *testing.T) {
 		// entry event should have edge to incoming opID
 		{"test", "entry"}: {g.OutEdges{{"Edge", incomingID[42:]}}, func(n g.Node) {
 			// trace ID should match incoming ID
-			assert.Equal(t, incomingID[2:42], n.Map["X-Trace"].(string)[2:42])
+			assert.Equal(t, incomingID[2:42], n.Map[tv.HTTPHeaderName].(string)[2:42])
 		}},
 		// exit event links to entry
 		{"test", "exit"}: {g.OutEdges{{"test", "entry"}}, func(n g.Node) {
 			// trace ID should match incoming ID
-			assert.Equal(t, incomingID[2:42], n.Map["X-Trace"].(string)[2:42])
+			assert.Equal(t, incomingID[2:42], n.Map[tv.HTTPHeaderName].(string)[2:42])
 			assert.Equal(t, "Arg", n.Map["Extra"])
 		}},
 	})

--- a/v1/tv/trace_test.go
+++ b/v1/tv/trace_test.go
@@ -250,6 +250,15 @@ func TestNoTraceExample(t *testing.T) {
 	assert.Len(t, r.Bufs, 0)
 }
 
+func BenchmarkNewTrace(b *testing.B) {
+	r := traceview.SetTestReporter()
+	r.ShouldTrace = false
+	for i := 0; i < b.N; i++ {
+		//_ = tv.NewTraceFromID("test", "", nil)
+		_ = tv.NewTrace("test")
+	}
+}
+
 func TestTraceFromMetadata(t *testing.T) {
 	r := traceview.SetTestReporter()
 

--- a/v1/tv/trace_test.go
+++ b/v1/tv/trace_test.go
@@ -257,9 +257,18 @@ func TestNoTraceExample(t *testing.T) {
 func BenchmarkNewTrace(b *testing.B) {
 	r := traceview.SetTestReporter()
 	r.ShouldTrace = false
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		//_ = tv.NewTraceFromID("test", "", nil)
 		_ = tv.NewTrace("test")
+	}
+}
+
+func BenchmarkNewTraceFromID(b *testing.B) {
+	r := traceview.SetTestReporter()
+	r.ShouldTrace = false
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tv.NewTraceFromID("test", "", nil)
 	}
 }
 


### PR DESCRIPTION
Small-to-medium-sized performance and feature improvements to v1 API:
- ~~Use 0-byte empty struct values rather than pointers to empty structs for untraced types such as nullTrace and nullSpan (gets rid of unnecessary allocations when not tracing)~~ Reverted: benchmarking showed we are already making 0 allocations when not tracing and that pointers are faster.
- More godoc & examples
- Add additional client layer helpers tv.Begin{Query,Cache,RemoteURL,RPC}Layer 
- Add panic() handling, reporting & re-raising to tv.HTTPHandler
- Add throughput & runtime metric reporting